### PR TITLE
🔒 fix: remove hardcoded default sqlite database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Invelog is a robust inventory management backend designed to track electronic co
 
 4. Run the server:
    ```bash
-   ./bin/invelog
+   DB_NAME=invelog.db ./bin/invelog
    ```
-   By default, the server will start on `localhost:8080` and create a local SQLite database named `invelog.db`.
+   By default, the server will start on `localhost:8080`. Note that a `DB_NAME` must be explicitly provided.
 
 ### API Documentation
 
@@ -72,7 +72,7 @@ Invelog uses environment variables to configure the database and server port.
 |----------|-------------|---------|
 | `PORT` | The port the HTTP server binds to | `8080` |
 | `DB_TYPE` | Database driver (`sqlite`, `postgres`, `mysql`) | `sqlite` |
-| `DB_NAME` | Database name or SQLite file path | `invelog.db` |
+| `DB_NAME` | Database name or SQLite file path | **(Required)** |
 | `DB_HOST` | Database host | `localhost` |
 | `DB_PORT` | Database port | `5432` |
 | `DB_USER` | Database user | `postgres` |

--- a/cmd/invelog/main.go
+++ b/cmd/invelog/main.go
@@ -29,7 +29,7 @@ func main() {
 	// 1. Initialize Database
 	dbConfig := database.Config{
 		Type:     getEnv("DB_TYPE", "sqlite"),
-		Database: getEnv("DB_NAME", "invelog.db"),
+		Database: getEnv("DB_NAME", ""),
 		Host:     getEnv("DB_HOST", "localhost"),
 		Port:     getEnv("DB_PORT", "5432"),
 		User:     getEnv("DB_USER", "postgres"),

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -25,16 +25,16 @@ type Config struct {
 }
 
 func Connect(cfg Config) (*gorm.DB, error) {
+	if cfg.Database == "" {
+		return nil, fmt.Errorf("database name (DB_NAME) must be provided")
+	}
+
 	var dialector gorm.Dialector
 
 	switch cfg.Type {
 	case "sqlite":
 		// Database acts as file path for sqlite
-		dbPath := cfg.Database
-		if dbPath == "" {
-			dbPath = "invelog.db"
-		}
-		dialector = sqlite.Open(dbPath)
+		dialector = sqlite.Open(cfg.Database)
 	case "postgres":
 		dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%s sslmode=%s",
 			cfg.Host, cfg.User, cfg.Password, cfg.Database, cfg.Port, cfg.SSLMode)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"testing"
+)
+
+func TestConnectEmptyDatabaseName(t *testing.T) {
+	tests := []struct {
+		name     string
+		dbType   string
+	}{
+		{"SQLite Empty DB Name", "sqlite"},
+		{"Postgres Empty DB Name", "postgres"},
+		{"MySQL Empty DB Name", "mysql"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Type:     tt.dbType,
+				Database: "",
+				Host:     "localhost",
+				Port:     "5432",
+				User:     "user",
+				Password: "password",
+				SSLMode:  "disable",
+			}
+
+			db, err := Connect(cfg)
+			if err == nil {
+				t.Errorf("Expected an error for empty database name with type %s, but got nil", tt.dbType)
+			} else if err.Error() != "database name (DB_NAME) must be provided" {
+				t.Errorf("Expected error message 'database name (DB_NAME) must be provided', got: %v", err)
+			}
+
+			if db != nil {
+				t.Errorf("Expected nil db when error occurs, but got %v", db)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded `invelog.db` fallback default for SQLite databases, forcing explicit configuration of the database name via `DB_NAME`.

⚠️ **Risk:** Hardcoded default database names can be a security vulnerability as they allow a system to spin up with predictable state files if not configured explicitly, and may result in an attacker manipulating the default file path. For PostgreSQL and MySQL, not enforcing a validation for empty database names could lead to improperly interpolated connection strings.

🛡️ **Solution:** Modified `cmd/invelog/main.go` to remove the default `invelog.db` and instead rely on explicit configuration for `DB_NAME`. Added strict validation logic to `database.Connect` in `pkg/database/database.go` that instantly returns an error for any database connection attempt with an empty `DB_NAME`. Unit tests have been written to guarantee that empty configurations result in failures safely. README documentation updated to reflect the change.

---
*PR created automatically by Jules for task [7579840201439790753](https://jules.google.com/task/7579840201439790753) started by @YK12321*