### PR TITLE
🔒 Fix Mass Assignment Vulnerability in UpdateCategory

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -174,7 +174,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/invelog_pkg_models.Category"
+                            "$ref": "#/definitions/pkg_api_handlers.UpdateCategoryInput"
                         }
                     }
                 ],
@@ -1724,6 +1724,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_handlers.UpdateCategoryInput": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -169,6 +169,13 @@ definitions:
       updated_at:
         type: string
     type: object
+  pkg_api_handlers.UpdateCategoryInput:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -309,7 +316,7 @@ paths:
         name: category
         required: true
         schema:
-          $ref: '#/definitions/invelog_pkg_models.Category'
+          $ref: '#/definitions/pkg_api_handlers.UpdateCategoryInput'
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/categories.go
+++ b/pkg/api/handlers/categories.go
@@ -9,6 +9,11 @@ import (
 	"github.com/google/uuid"
 )
 
+type UpdateCategoryInput struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+}
+
 // @Summary Create Category
 // @Description Create a new category
 // @Tags Categories
@@ -76,7 +81,7 @@ func (h *Handler) GetCategory(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param id path string true "Category ID"
-// @Param category body models.Category true "Category Data"
+// @Param category body UpdateCategoryInput true "Category Data"
 // @Success 200 {object} models.Category
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -94,11 +99,19 @@ func (h *Handler) UpdateCategory(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&category); err != nil {
+	var input UpdateCategoryInput
+	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	category.ID = id // Ensure ID cannot be changed
+
+	// Map updated fields
+	if input.Name != nil {
+		category.Name = *input.Name
+	}
+	if input.Description != nil {
+		category.Description = *input.Description
+	}
 
 	if err := h.DB.Save(&category).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update category"})


### PR DESCRIPTION
🎯 **What:**
The vulnerability fixed is a mass assignment in the `UpdateCategory` handler, where users could inadvertently or maliciously update fields they weren't intended to change (like ID or CreatedAt/DeletedAt).

⚠️ **Risk:**
If left unfixed, attackers could manipulate sensitive model properties, leading to data corruption or potentially further authorization bypasses depending on the application context.

🛡️ **Solution:**
I introduced a Data Transfer Object (DTO) `UpdateCategoryInput` for mapping incoming JSON payloads to the Category model, ensuring only the `Name` and `Description` properties are updated. I also utilized pointer fields in the DTO to handle partial updates properly (if the user only provides `Name`, the `Description` remains unchanged). The Swagger annotations were regenerated accordingly.

---
*PR created automatically by Jules for task [15330264933268576051](https://jules.google.com/task/15330264933268576051) started by @YK12321*