### PR TITLE
🔒 Fix mass assignment vulnerability in UpdateItem

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -795,12 +795,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Item Data",
+                        "description": "Item Update Data",
                         "name": "item",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/invelog_pkg_models.Item"
+                            "$ref": "#/definitions/pkg_api_handlers.UpdateItemInput"
                         }
                     }
                 ],
@@ -1724,6 +1724,38 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "pkg_api_handlers.UpdateItemInput": {
+            "type": "object",
+            "properties": {
+                "category_id": {
+                    "type": "string"
+                },
+                "container_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "individual_notes": {
+                    "type": "string"
+                },
+                "item_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "origin_location_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "integer"
+                },
+                "serial_number": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -169,6 +169,27 @@ definitions:
       updated_at:
         type: string
     type: object
+  pkg_api_handlers.UpdateItemInput:
+    properties:
+      category_id:
+        type: string
+      container_id:
+        type: string
+      description:
+        type: string
+      individual_notes:
+        type: string
+      item_type_id:
+        type: string
+      name:
+        type: string
+      origin_location_id:
+        type: string
+      quantity:
+        type: integer
+      serial_number:
+        type: string
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -718,12 +739,12 @@ paths:
         name: id
         required: true
         type: string
-      - description: Item Data
+      - description: Item Update Data
         in: body
         name: item
         required: true
         schema:
-          $ref: '#/definitions/invelog_pkg_models.Item'
+          $ref: '#/definitions/pkg_api_handlers.UpdateItemInput'
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/items.go
+++ b/pkg/api/handlers/items.go
@@ -70,13 +70,25 @@ func (h *Handler) GetItem(c *gin.Context) {
 	c.JSON(http.StatusOK, item)
 }
 
+type UpdateItemInput struct {
+	Name             *string    `json:"name"`
+	Description      *string    `json:"description"`
+	Quantity         *int       `json:"quantity"`
+	IndividualNotes  *string    `json:"individual_notes"`
+	SerialNumber     *string    `json:"serial_number"`
+	ItemTypeID       *uuid.UUID `json:"item_type_id"`
+	CategoryID       *uuid.UUID `json:"category_id"`
+	ContainerID      *uuid.UUID `json:"container_id"`
+	OriginLocationID *uuid.UUID `json:"origin_location_id"`
+}
+
 // @Summary Update Item
 // @Description Update an item by ID
 // @Tags Items
 // @Accept json
 // @Produce json
 // @Param id path string true "Item ID"
-// @Param item body models.Item true "Item Data"
+// @Param item body UpdateItemInput true "Item Update Data"
 // @Success 200 {object} models.Item
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -94,11 +106,39 @@ func (h *Handler) UpdateItem(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&item); err != nil {
+	var input UpdateItemInput
+	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	item.ID = id // Ensure ID cannot be changed
+
+	if input.Name != nil {
+		item.Name = *input.Name
+	}
+	if input.Description != nil {
+		item.Description = *input.Description
+	}
+	if input.Quantity != nil {
+		item.Quantity = *input.Quantity
+	}
+	if input.IndividualNotes != nil {
+		item.IndividualNotes = *input.IndividualNotes
+	}
+	if input.SerialNumber != nil {
+		item.SerialNumber = *input.SerialNumber
+	}
+	if input.ItemTypeID != nil {
+		item.ItemTypeID = input.ItemTypeID
+	}
+	if input.CategoryID != nil {
+		item.CategoryID = input.CategoryID
+	}
+	if input.ContainerID != nil {
+		item.ContainerID = input.ContainerID
+	}
+	if input.OriginLocationID != nil {
+		item.OriginLocationID = input.OriginLocationID
+	}
 
 	if err := h.DB.Save(&item).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item"})


### PR DESCRIPTION
🎯 What: Fixed a mass assignment vulnerability in the `UpdateItem` endpoint where a user could manipulate sensitive fields like `CreatedAt` and `CreatedBy`.
⚠️ Risk: Attackers could overwrite fields that shouldn't be modifiable.
🛡️ Solution: Implemented a Data Transfer Object (DTO) `UpdateItemInput` containing only allowed fields, and explicitly mapped non-nil fields to the DB object. Also regenerated the Swagger documentation.

---
*PR created automatically by Jules for task [14175396247357941459](https://jules.google.com/task/14175396247357941459) started by @YK12321*