### PR TITLE
🔒 Fix mass assignment vulnerability in CreateItem

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -714,7 +714,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/invelog_pkg_models.Item"
+                            "$ref": "#/definitions/invelog_pkg_dto.CreateItemRequest"
                         }
                     }
                 ],
@@ -1475,6 +1475,38 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "invelog_pkg_dto.CreateItemRequest": {
+            "type": "object",
+            "properties": {
+                "category_id": {
+                    "type": "string"
+                },
+                "container_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "individual_notes": {
+                    "type": "string"
+                },
+                "item_type_id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "origin_location_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "integer"
+                },
+                "serial_number": {
+                    "type": "string"
+                }
+            }
+        },
         "invelog_pkg_models.ActivityLog": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,26 @@
 basePath: /api/v1
 definitions:
+  invelog_pkg_dto.CreateItemRequest:
+    properties:
+      category_id:
+        type: string
+      container_id:
+        type: string
+      description:
+        type: string
+      individual_notes:
+        type: string
+      item_type_id:
+        type: string
+      name:
+        type: string
+      origin_location_id:
+        type: string
+      quantity:
+        type: integer
+      serial_number:
+        type: string
+    type: object
   invelog_pkg_models.ActivityLog:
     properties:
       action:
@@ -638,7 +659,7 @@ paths:
         name: item
         required: true
         schema:
-          $ref: '#/definitions/invelog_pkg_models.Item'
+          $ref: '#/definitions/invelog_pkg_dto.CreateItemRequest'
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/items.go
+++ b/pkg/api/handlers/items.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -14,15 +15,32 @@ import (
 // @Tags Items
 // @Accept json
 // @Produce json
-// @Param item body models.Item true "Item Data"
+// @Param item body dto.CreateItemRequest true "Item Data"
 // @Success 201 {object} models.Item
 // @Failure 400 {object} map[string]string
 // @Router /items [post]
 func (h *Handler) CreateItem(c *gin.Context) {
-	var item models.Item
-	if err := c.ShouldBindJSON(&item); err != nil {
+	var req dto.CreateItemRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+
+	item := models.Item{
+		Name:             req.Name,
+		Description:      req.Description,
+		IndividualNotes:  req.IndividualNotes,
+		SerialNumber:     req.SerialNumber,
+		ItemTypeID:       req.ItemTypeID,
+		CategoryID:       req.CategoryID,
+		ContainerID:      req.ContainerID,
+		OriginLocationID: req.OriginLocationID,
+	}
+
+	if req.Quantity != nil {
+		item.Quantity = *req.Quantity
+	} else {
+		item.Quantity = 1
 	}
 
 	if err := h.DB.Create(&item).Error; err != nil {

--- a/pkg/dto/item.go
+++ b/pkg/dto/item.go
@@ -1,0 +1,15 @@
+package dto
+
+import "github.com/google/uuid"
+
+type CreateItemRequest struct {
+	Name             string     `json:"name"`
+	Description      string     `json:"description"`
+	Quantity         *int       `json:"quantity"`
+	IndividualNotes  string     `json:"individual_notes"`
+	SerialNumber     string     `json:"serial_number"`
+	ItemTypeID       *uuid.UUID `json:"item_type_id"`
+	CategoryID       *uuid.UUID `json:"category_id"`
+	ContainerID      *uuid.UUID `json:"container_id"`
+	OriginLocationID *uuid.UUID `json:"origin_location_id"`
+}


### PR DESCRIPTION
🎯 **What:** The `CreateItem` API endpoint had a mass assignment vulnerability because it directly bound incoming JSON payloads to the database model (`models.Item`).
⚠️ **Risk:** A malicious user could potentially overwrite sensitive, non-updatable fields such as `ID`, `CreatedBy`, `CheckedOut`, or relationships that should not be manipulated via direct API input.
🛡️ **Solution:** Introduced a `CreateItemRequest` Data Transfer Object (DTO) in `pkg/dto` that exclusively exposes safe fields for assignment. The handler now binds to this DTO and maps safely to the `models.Item`, using pointers to properly discern between omitted fields and intentional zero values (such as `Quantity`). Swagger docs were also updated.

---
*PR created automatically by Jules for task [15538080480518627271](https://jules.google.com/task/15538080480518627271) started by @YK12321*