### PR TITLE
fix: Fix mass assignment vulnerability in UpdateCategory

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -174,7 +174,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/invelog_pkg_models.Category"
+                            "$ref": "#/definitions/invelog_pkg_dto.UpdateCategoryInput"
                         }
                     }
                 ],
@@ -1517,6 +1517,17 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "serial_number": {
+                    "type": "string"
+                }
+            }
+        },
+        "invelog_pkg_dto.UpdateCategoryInput": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -21,6 +21,13 @@ definitions:
       serial_number:
         type: string
     type: object
+  invelog_pkg_dto.UpdateCategoryInput:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+    type: object
   invelog_pkg_models.ActivityLog:
     properties:
       action:
@@ -351,7 +358,7 @@ paths:
         name: category
         required: true
         schema:
-          $ref: '#/definitions/invelog_pkg_models.Category'
+          $ref: '#/definitions/invelog_pkg_dto.UpdateCategoryInput'
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/categories.go
+++ b/pkg/api/handlers/categories.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -76,7 +77,7 @@ func (h *Handler) GetCategory(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param id path string true "Category ID"
-// @Param category body models.Category true "Category Data"
+// @Param category body dto.UpdateCategoryInput true "Category Data"
 // @Success 200 {object} models.Category
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -94,11 +95,19 @@ func (h *Handler) UpdateCategory(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&category); err != nil {
+	var input dto.UpdateCategoryInput
+	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	category.ID = id // Ensure ID cannot be changed
+
+	// Map updated fields
+	if input.Name != nil {
+		category.Name = *input.Name
+	}
+	if input.Description != nil {
+		category.Description = *input.Description
+	}
 
 	if err := h.DB.Save(&category).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update category"})

--- a/pkg/dto/category.go
+++ b/pkg/dto/category.go
@@ -1,0 +1,6 @@
+package dto
+
+type UpdateCategoryInput struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+}


### PR DESCRIPTION
Resolves merge conflict for pull request #5 by applying the security fix for the `UpdateCategory` handler directly to `main` while maintaining clean git history and aligning with codebase maintainability guidelines.

- Created `dto.UpdateCategoryInput` in `pkg/dto/category.go`
- Updated `UpdateCategory` in `pkg/api/handlers/categories.go` to bind to the DTO instead of the `models.Category` model.
- Updated Swagger annotations in `pkg/api/handlers/categories.go`.
- Regenerated Swagger documentation.

---
*PR created automatically by Jules for task [4076711196478712578](https://jules.google.com/task/4076711196478712578) started by @YK12321*