### PR TITLE
⚡ Bolt: Add pagination to ListActivityLogs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Unbounded List Queries Anti-Pattern
+**Learning:** Found several API handlers (like `ListActivityLogs`, `ListLocations`, `ListCategories`, etc.) using unbounded `h.DB.Find(&items)` queries. In particular, `ActivityLogs` can grow indefinitely with every user action. An unbounded query on this table will result in massive JSON payloads and runaway memory allocation (O(N) space complexity and DB transfer overhead).
+**Action:** Always implement pagination (`limit` and `offset`) for list endpoints, particularly for unbounded log tables. Use a sensible default limit (e.g., 100) and max limit.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -34,6 +34,20 @@ const docTemplate = `{
                     "Activity Logs"
                 ],
                 "summary": "List Activity Logs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 100, max 1000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -236,6 +236,15 @@ paths:
   /activity-logs:
     get:
       description: Get all activity logs
+      parameters:
+      - description: Limit (default 100, max 1000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/activity_logs.go
+++ b/pkg/api/handlers/activity_logs.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/models"
 
@@ -12,10 +13,28 @@ import (
 // @Description Get all activity logs
 // @Tags Activity Logs
 // @Produce json
+// @Param limit query int false "Limit (default 100, max 1000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.ActivityLog
 // @Router /activity-logs [get]
 func (h *Handler) ListActivityLogs(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "100")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var logs []models.ActivityLog
-	h.DB.Order("created_at desc").Find(&logs)
+	h.DB.Order("created_at desc").Limit(limit).Offset(offset).Find(&logs)
 	c.JSON(http.StatusOK, logs)
 }


### PR DESCRIPTION
💡 What: Implemented `limit` and `offset` query parameters in the `ListActivityLogs` handler to restrict the number of results returned, defaulting to 100 with a max of 1000.
🎯 Why: Unbounded `h.DB.Find(&logs)` calls on an append-only log table create an O(N) memory leak and excessive database transfer overhead as the application scales.
📊 Impact: Reduces memory footprint from O(N) to O(limit), significantly improving stability and performance for large repositories.
🔬 Measurement: Verify by querying `/activity-logs` to confirm it returns a maximum of 100 items by default, and that `limit` and `offset` work correctly.

---
*PR created automatically by Jules for task [18320479993622614334](https://jules.google.com/task/18320479993622614334) started by @YK12321*