### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unbounded Query DoS in ActivityLogs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-23 - [Unbounded Query DoS]
+**Vulnerability:** The `/api/v1/activity-logs` endpoint queried the entire `activity_logs` table using `Find()` without a limit or pagination, causing the result set to grow continuously. This leads to unbounded memory consumption on the server and excessive database load, constituting a Denial of Service (DoS) risk.
+**Learning:** In a production application handling an ever-growing dataset (like audit logs), fetching all records at once should never be permitted. Even during initial development, endpoints accessing list resources must implement bounded limits to prevent system exhaustion under load.
+**Prevention:** Always implement pagination (e.g., using limit and offset defaults) for list-based API endpoints. When possible, add hard upper limits on the maximum number of items that can be fetched in a single query to ensure resource usage remains predictable and safe.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -34,6 +34,20 @@ const docTemplate = `{
                     "Activity Logs"
                 ],
                 "summary": "List Activity Logs",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 20, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -236,6 +236,15 @@ paths:
   /activity-logs:
     get:
       description: Get all activity logs
+      parameters:
+      - description: Limit (default 20, max 100)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/activity_logs.go
+++ b/pkg/api/handlers/activity_logs.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/models"
 
@@ -12,10 +14,39 @@ import (
 // @Description Get all activity logs
 // @Tags Activity Logs
 // @Produce json
+// @Param limit query int false "Limit (default 20, max 100)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.ActivityLog
 // @Router /activity-logs [get]
 func (h *Handler) ListActivityLogs(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "20")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var logs []models.ActivityLog
-	h.DB.Order("created_at desc").Find(&logs)
+	var total int64
+
+	// Get total count
+	h.DB.Model(&models.ActivityLog{}).Count(&total)
+
+	// Get paginated results
+	h.DB.Order("created_at desc").Limit(limit).Offset(offset).Find(&logs)
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, logs)
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/v1/activity-logs` endpoint fetched all logs using an unbounded `Find()` query without any limit or pagination. As the `activity_logs` table grows over time, this can lead to unbounded memory consumption and database overload, constituting a Denial of Service (DoS) risk.
🎯 Impact: An attacker or a normal user fetching logs could crash the application by exhausting system memory and tying up database connections.
🔧 Fix: Implemented a default limit of 20 and a maximum hard limit of 100 on the `/activity-logs` endpoint. Added `X-Total-Count`, `X-Limit`, and `X-Offset` response headers to supply pagination details without breaking the existing array response format. Swagger documentation was also regenerated.
✅ Verification: Call the endpoint with and without limit parameters and verify that it returns a maximum of 100 items along with the correct pagination headers.

---
*PR created automatically by Jules for task [15167158469257481011](https://jules.google.com/task/15167158469257481011) started by @YK12321*