### PR TITLE
⚡ Bolt: Add pagination to ListItems endpoint

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - Retrofitting pagination to unbounded endpoints
+**Learning:** When retrofitting pagination to an endpoint that previously returned all records (unbounded), standard `limit=20` defaults will break existing clients that expect the full dataset.
+**Action:** Always use high limits (e.g., limit=1000, max=10000) and preserve the JSON array response body by returning pagination metadata in HTTP headers (`X-Total-Count`, `X-Limit`, `X-Offset`) to maintain backward compatibility.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -711,6 +711,20 @@ const docTemplate = `{
                     "Items"
                 ],
                 "summary": "List Items",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -683,6 +683,15 @@ paths:
   /items:
     get:
       description: Get all items
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/items.go
+++ b/pkg/api/handlers/items.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -56,11 +58,37 @@ func (h *Handler) CreateItem(c *gin.Context) {
 // @Description Get all items
 // @Tags Items
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Item
 // @Router /items [get]
 func (h *Handler) ListItems(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	var totalCount int64
+	h.DB.Model(&models.Item{}).Count(&totalCount)
+
 	var items []models.Item
-	h.DB.Preload("Category").Preload("Container").Find(&items)
+	h.DB.Preload("Category").Preload("Container").Limit(limit).Offset(offset).Find(&items)
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", totalCount))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, items)
 }
 

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -6,8 +6,8 @@ import (
 
 func TestConnectEmptyDatabaseName(t *testing.T) {
 	tests := []struct {
-		name     string
-		dbType   string
+		name   string
+		dbType string
 	}{
 		{"SQLite Empty DB Name", "sqlite"},
 		{"Postgres Empty DB Name", "postgres"},


### PR DESCRIPTION
💡 What: Added pagination (`limit` and `offset` query parameters) to the `GET /items` endpoint, using HTTP headers for metadata to maintain backward compatibility.
🎯 Why: The previous implementation was using an unbounded `Find(&items)` query with preloads. Returning large collections without a limit can cause performance bottlenecks and massive memory usage, especially as the system scales.
📊 Impact: Prevents out-of-memory errors and excessive database load by controlling the maximum number of items retrieved in a single request.
🔬 Measurement: Verified that tests pass and the Swagger documentation is successfully updated to document the new parameters. The headers `X-Total-Count`, `X-Limit`, and `X-Offset` are now present in the response.

---
*PR created automatically by Jules for task [15431822819075261884](https://jules.google.com/task/15431822819075261884) started by @YK12321*