### PR TITLE
🛡️ Sentinel: [HIGH] Fix mass assignment vulnerability in ItemType handlers

### DIFF
--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -15,15 +16,24 @@ import (
 // @Tags ItemTypes
 // @Accept json
 // @Produce json
-// @Param itemType body models.ItemType true "ItemType Data"
+// @Param itemType body dto.CreateItemTypeRequest true "ItemType Data"
 // @Success 201 {object} models.ItemType
 // @Failure 400 {object} map[string]string
 // @Router /item-types [post]
 func (h *Handler) CreateItemType(c *gin.Context) {
-	var itemType models.ItemType
-	if err := c.ShouldBindJSON(&itemType); err != nil {
+	var req dto.CreateItemTypeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+
+	itemType := models.ItemType{
+		Name:           req.Name,
+		Description:    req.Description,
+		Specifications: req.Specifications,
+		Manufacturer:   req.Manufacturer,
+		PartNumber:     req.PartNumber,
+		CategoryID:     req.CategoryID,
 	}
 
 	if err := h.DB.Create(&itemType).Error; err != nil {
@@ -118,6 +128,9 @@ func (h *Handler) UpdateItemType(c *gin.Context) {
 		return
 	}
 	itemType.ID = id // Ensure ID cannot be changed
+
+	// Prevent mass assignment of associations
+	itemType.Category = nil
 
 	if err := h.DB.Save(&itemType).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item type"})

--- a/pkg/dto/item_type.go
+++ b/pkg/dto/item_type.go
@@ -1,0 +1,12 @@
+package dto
+
+import "github.com/google/uuid"
+
+type CreateItemTypeRequest struct {
+	Name           string     `json:"name" binding:"required"`
+	Description    string     `json:"description"`
+	Specifications string     `json:"specifications"`
+	Manufacturer   string     `json:"manufacturer"`
+	PartNumber     string     `json:"part_number"`
+	CategoryID     *uuid.UUID `json:"category_id"`
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Mass assignment vulnerability in the `ItemType` creation and update handlers. Bypassing input filtering, attackers could potentially inject arbitrary JSON structures and mass-assign sensitive entity associations (like the relational `Category` object).
🎯 Impact: Attackers could manipulate unrelated tables by exploiting GORM's automatic association creation/modification, leading to unauthorized data alteration.
🔧 Fix:
- Created a new DTO `dto.CreateItemTypeRequest` that safely maps only expected scalar attributes for the Create handler.
- Updated `CreateItemType` to bind payloads to the specific DTO.
- Handled the Update payload by explicitly setting the relational pointer `itemType.Category = nil` prior to `DB.Save()`.
✅ Verification: Tested via `go test ./...` and compiled to ensure no regressions.

---
*PR created automatically by Jules for task [17752103882185108081](https://jules.google.com/task/17752103882185108081) started by @YK12321*