### PR TITLE
⚡ Bolt: [performance improvement] Add pagination to ListContainers to prevent memory exhaustion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-06-02 - ListItems pagination performance bottleneck
 **Learning:** Returning large unbounded collections from `GORM.Find()` calls without any `Limit` constraint can cause massive performance and memory issues, especially when paired with `.Preload()`. Using limits and offsets allows for controlled data fetching.
 **Action:** Always verify that endpoint logic correctly limits query results when working with list routes. For backward compatibility, make sure to use reasonable default boundaries (e.g. `1000`) and metadata headers (e.g., `X-Total-Count`).
+
+## 2026-06-07 - Unbounded query missing pagination in ListContainers
+**Learning:** Like ListItems, the ListContainers endpoint was returning unbounded queries causing severe memory spikes. This indicates that while pagination patterns exist, they were not universally applied during development to all root aggregate endpoints.
+**Action:** When working on API listings or adding new entities, actively ensure pagination logic with fallback defaults (e.g., limit=1000) and headers (X-Total-Count, X-Limit, X-Offset) is implemented to prevent catastrophic memory issues on growth.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -272,6 +272,20 @@ const docTemplate = `{
                     "Containers"
                 ],
                 "summary": "List Containers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -303,8 +317,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -704,7 +717,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1518,8 +1531,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1554,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -412,6 +408,15 @@ paths:
   /containers:
     get:
       description: Get all containers
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -434,11 +439,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +706,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -47,11 +49,46 @@ func (h *Handler) CreateContainer(c *gin.Context) {
 // @Description Get all containers
 // @Tags Containers
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Container
 // @Router /containers [get]
 func (h *Handler) ListContainers(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var containers []models.Container
-	h.DB.Preload("Location").Preload("Parent").Preload("Project").Find(&containers)
+	var total int64
+
+	// Get total count
+	if err := h.DB.Model(&models.Container{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	// Get paginated results
+	if err := h.DB.Preload("Location").Preload("Parent").Preload("Project").Limit(limit).Offset(offset).Find(&containers).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, containers)
 }
 

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -6,8 +6,8 @@ import (
 
 func TestConnectEmptyDatabaseName(t *testing.T) {
 	tests := []struct {
-		name     string
-		dbType   string
+		name   string
+		dbType string
 	}{
 		{"SQLite Empty DB Name", "sqlite"},
 		{"Postgres Empty DB Name", "postgres"},


### PR DESCRIPTION
💡 **What**: Implemented pagination parameters (`limit`, `offset`) on the `/containers` GET endpoint and exposed standard pagination metadata via HTTP headers (`X-Total-Count`, `X-Limit`, `X-Offset`).
🎯 **Why**: The unbounded `Find()` query combined with multiple GORM `.Preload()` calls would retrieve the entire table contents into memory, causing major performance bottlenecks as database size increases.
📊 **Impact**: This bounded retrieval will significantly lower memory consumption, reduce query latency, and decrease database load for listing containers.
🔬 **Measurement**: Verify by using a tool like Postman to query the `/containers` endpoint and confirm the `X-Total-Count` header is returned, and that by adjusting `?limit=10`, the payload only contains 10 items.

---
*PR created automatically by Jules for task [14684751225372811696](https://jules.google.com/task/14684751225372811696) started by @YK12321*