### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+
+## 2026-06-07 - [Hardcoded Database Credentials]
+**Vulnerability:** The application was using hardcoded default credentials ("postgres" / "postgres") for `DB_USER` and `DB_PASSWORD` when connecting to the database.
+**Learning:** Using hardcoded default credentials is a CRITICAL security vulnerability. It can expose databases if environment variables are not correctly configured in production.
+**Prevention:** Never use hardcoded secrets or default passwords in source code. Always enforce that credentials are provided externally via secure environment variables or a secrets manager.

--- a/cmd/invelog/main.go
+++ b/cmd/invelog/main.go
@@ -32,8 +32,8 @@ func main() {
 		Database: getEnv("DB_NAME", ""),
 		Host:     getEnv("DB_HOST", "localhost"),
 		Port:     getEnv("DB_PORT", "5432"),
-		User:     getEnv("DB_USER", "postgres"),
-		Password: getEnv("DB_PASSWORD", "postgres"),
+		User:     getEnv("DB_USER", ""),
+		Password: getEnv("DB_PASSWORD", ""),
 		SSLMode:  getEnv("DB_SSLMODE", "disable"),
 	}
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used hardcoded fallback values (`"postgres"`) for `DB_USER` and `DB_PASSWORD`.
🎯 Impact: If environment variables were omitted, the application could inadvertently use well-known default credentials, which is a major security risk.
🔧 Fix: Removed the default string fallbacks for `DB_USER` and `DB_PASSWORD` in `cmd/invelog/main.go`, replacing them with empty strings.
✅ Verification: Ensure that running the server now strictly requires providing database credentials securely via environment variables. Tests pass without breaking existing logic since tests use valid mock inputs or SQLite.

---
*PR created automatically by Jules for task [2507978509602738369](https://jules.google.com/task/2507978509602738369) started by @YK12321*