### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded database credentials fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+
+## 2024-06-08 - [Hardcoded Default Database Credentials]
+**Vulnerability:** The application used hardcoded fallback values (`postgres`/`postgres`) for database connections when `DB_USER` and `DB_PASSWORD` environment variables were not provided.
+**Learning:** Hardcoding default database credentials as fallbacks can lead to databases being inadvertently exposed or accessible using widely-known default combinations in misconfigured environments.
+**Prevention:** Always use explicit environment variables for sensitive configurations like database credentials and avoid providing fallback values within the application code to ensure explicit and intentional configuration.

--- a/cmd/invelog/main.go
+++ b/cmd/invelog/main.go
@@ -32,8 +32,8 @@ func main() {
 		Database: getEnv("DB_NAME", ""),
 		Host:     getEnv("DB_HOST", "localhost"),
 		Port:     getEnv("DB_PORT", "5432"),
-		User:     getEnv("DB_USER", "postgres"),
-		Password: getEnv("DB_PASSWORD", "postgres"),
+		User:     getEnv("DB_USER", ""),
+		Password: getEnv("DB_PASSWORD", ""),
 		SSLMode:  getEnv("DB_SSLMODE", "disable"),
 	}
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The application was using hardcoded default values (`postgres`/`postgres`) for the database credentials when the `DB_USER` and `DB_PASSWORD` environment variables were not provided.
🎯 **Impact:** If deployed in an environment where these variables are accidentally omitted, the application would attempt to connect (and potentially expose data) using widely-known default credentials, which is a major security risk.
🔧 **Fix:** Replaced the hardcoded fallback values for `DB_USER` and `DB_PASSWORD` with empty strings `""` in `cmd/invelog/main.go`. This forces operators to explicitly configure these values and prevents accidental insecure connections.
✅ **Verification:** Verified by checking `cmd/invelog/main.go`, and running `go build -o bin/invelog cmd/invelog/main.go` and `go test ./...` to ensure compilation and tests still pass.

---
*PR created automatically by Jules for task [511180613865823831](https://jules.google.com/task/511180613865823831) started by @YK12321*