### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Mass Assignment in ItemType Creation and Updates

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -303,8 +303,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -542,7 +541,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ItemType"
+                            "$ref": "#/definitions/dto.CreateItemTypeRequest"
                         }
                     }
                 ],
@@ -704,7 +703,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1518,8 +1517,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1540,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {
@@ -1570,6 +1568,32 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "serial_number": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreateItemTypeRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "category_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "manufacturer": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "part_number": {
+                    "type": "string"
+                },
+                "specifications": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -39,6 +35,23 @@ definitions:
         type: integer
       serial_number:
         type: string
+    type: object
+  dto.CreateItemTypeRequest:
+    properties:
+      category_id:
+        type: string
+      description:
+        type: string
+      manufacturer:
+        type: string
+      name:
+        type: string
+      part_number:
+        type: string
+      specifications:
+        type: string
+    required:
+    - name
     type: object
   dto.UpdateCategoryInput:
     properties:
@@ -434,11 +447,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -595,7 +604,7 @@ paths:
         name: itemType
         required: true
         schema:
-          $ref: '#/definitions/models.ItemType'
+          $ref: '#/definitions/dto.CreateItemTypeRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +714,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query

--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -15,15 +16,24 @@ import (
 // @Tags ItemTypes
 // @Accept json
 // @Produce json
-// @Param itemType body models.ItemType true "ItemType Data"
+// @Param itemType body dto.CreateItemTypeRequest true "ItemType Data"
 // @Success 201 {object} models.ItemType
 // @Failure 400 {object} map[string]string
 // @Router /item-types [post]
 func (h *Handler) CreateItemType(c *gin.Context) {
-	var itemType models.ItemType
-	if err := c.ShouldBindJSON(&itemType); err != nil {
+	var req dto.CreateItemTypeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+
+	itemType := models.ItemType{
+		Name:           req.Name,
+		Description:    req.Description,
+		Specifications: req.Specifications,
+		Manufacturer:   req.Manufacturer,
+		PartNumber:     req.PartNumber,
+		CategoryID:     req.CategoryID,
 	}
 
 	if err := h.DB.Create(&itemType).Error; err != nil {
@@ -118,6 +128,9 @@ func (h *Handler) UpdateItemType(c *gin.Context) {
 		return
 	}
 	itemType.ID = id // Ensure ID cannot be changed
+
+	// Prevent mass assignment of associations
+	itemType.Category = nil
 
 	if err := h.DB.Save(&itemType).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item type"})

--- a/pkg/dto/item_type.go
+++ b/pkg/dto/item_type.go
@@ -1,0 +1,12 @@
+package dto
+
+import "github.com/google/uuid"
+
+type CreateItemTypeRequest struct {
+	Name           string     `json:"name" binding:"required"`
+	Description    string     `json:"description"`
+	Specifications string     `json:"specifications"`
+	Manufacturer   string     `json:"manufacturer"`
+	PartNumber     string     `json:"part_number"`
+	CategoryID     *uuid.UUID `json:"category_id"`
+}


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `/item-types` POST and PUT endpoints were vulnerable to mass assignment. The `CreateItemType` endpoint directly bound the incoming JSON payload to the GORM `models.ItemType` struct. Similarly, the `UpdateItemType` endpoint did not prevent updates to the `Category` association. This allowed attackers to potentially modify sensitive relationship fields like `Category` by passing nested JSON objects.
🎯 **Impact:** An attacker could modify nested associations, potentially reassigning item types to different categories or overwriting existing category definitions when database configurations enable `FullSaveAssociations`.
🔧 **Fix:** 
- Created a dedicated `dto.CreateItemTypeRequest` for the `CreateItemType` endpoint that only exposes primitive scalar fields.
- Mapped the incoming DTO explicitly to the domain model in the create handler to prevent mass assignment of the `Category` association.
- Explicitly set `itemType.Category = nil` before saving in the `UpdateItemType` handler to prevent mass assignment during updates.
- Updated the Swagger annotations to reflect the new DTO payload for the create endpoint.
✅ **Verification:** Verified by reviewing the updated handlers, ensuring the new DTO is used correctly, and confirming that the Swagger documentation was generated successfully. Ran the full test suite (`go test ./...`) which passed without regressions.

---
*PR created automatically by Jules for task [10201383802967114191](https://jules.google.com/task/10201383802967114191) started by @YK12321*