### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix mass assignment vulnerability in Item Types

### DIFF
--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -15,15 +16,24 @@ import (
 // @Tags ItemTypes
 // @Accept json
 // @Produce json
-// @Param itemType body models.ItemType true "ItemType Data"
+// @Param itemType body dto.CreateItemTypeRequest true "ItemType Data"
 // @Success 201 {object} models.ItemType
 // @Failure 400 {object} map[string]string
 // @Router /item-types [post]
 func (h *Handler) CreateItemType(c *gin.Context) {
-	var itemType models.ItemType
-	if err := c.ShouldBindJSON(&itemType); err != nil {
+	var req dto.CreateItemTypeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+
+	itemType := models.ItemType{
+		Name:           req.Name,
+		Description:    req.Description,
+		Specifications: req.Specifications,
+		Manufacturer:   req.Manufacturer,
+		PartNumber:     req.PartNumber,
+		CategoryID:     req.CategoryID,
 	}
 
 	if err := h.DB.Create(&itemType).Error; err != nil {
@@ -95,7 +105,7 @@ func (h *Handler) GetItemType(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param id path string true "ItemType ID"
-// @Param itemType body models.ItemType true "ItemType Data"
+// @Param itemType body dto.UpdateItemTypeRequest true "ItemType Data"
 // @Success 200 {object} models.ItemType
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -113,11 +123,32 @@ func (h *Handler) UpdateItemType(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&itemType); err != nil {
+	var req dto.UpdateItemTypeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	itemType.ID = id // Ensure ID cannot be changed
+
+	if req.Name != nil {
+		itemType.Name = *req.Name
+	}
+	if req.Description != nil {
+		itemType.Description = *req.Description
+	}
+	if req.Specifications != nil {
+		itemType.Specifications = *req.Specifications
+	}
+	if req.Manufacturer != nil {
+		itemType.Manufacturer = *req.Manufacturer
+	}
+	if req.PartNumber != nil {
+		itemType.PartNumber = *req.PartNumber
+	}
+	if req.CategoryID != nil {
+		itemType.CategoryID = req.CategoryID
+	}
+
+	itemType.Category = nil
 
 	if err := h.DB.Save(&itemType).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item type"})

--- a/pkg/dto/item_type.go
+++ b/pkg/dto/item_type.go
@@ -1,0 +1,21 @@
+package dto
+
+import "github.com/google/uuid"
+
+type CreateItemTypeRequest struct {
+	Name           string     `json:"name" binding:"required"`
+	Description    string     `json:"description"`
+	Specifications string     `json:"specifications"`
+	Manufacturer   string     `json:"manufacturer"`
+	PartNumber     string     `json:"part_number"`
+	CategoryID     *uuid.UUID `json:"category_id"`
+}
+
+type UpdateItemTypeRequest struct {
+	Name           *string    `json:"name"`
+	Description    *string    `json:"description"`
+	Specifications *string    `json:"specifications"`
+	Manufacturer   *string    `json:"manufacturer"`
+	PartNumber     *string    `json:"part_number"`
+	CategoryID     *uuid.UUID `json:"category_id"`
+}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `CreateItemType` and `UpdateItemType` API handlers directly bound incoming JSON payloads to the `models.ItemType` GORM domain model. Because this model contains an embedded relationship struct (`Category`), an attacker could pass a nested JSON object (e.g., `{"category": {"id": "...", "name": "HACKED"}}`) and maliciously perform unauthorized mass assignment or overwrite related entities in the database during save.
🎯 Impact: Attackers could overwrite categories globally or corrupt database relationships.
🔧 Fix: Created dedicated Data Transfer Objects (DTOs) in `pkg/dto/item_type.go` (`CreateItemTypeRequest` and `UpdateItemTypeRequest`) that only allow specifying primitive fields (like `category_id`) and explicitly map them to the domain model, completely removing the mass assignment vector.
✅ Verification: Tested via explicit exploit payload (`exploit_test.go`) before and after the fix. Also verified via `go test ./...` and `go build`.

---
*PR created automatically by Jules for task [4114464516988476654](https://jules.google.com/task/4114464516988476654) started by @YK12321*