### PR TITLE
⚡ Bolt: Prevent Unbounded Memory Growth on Containers List with Pagination

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-02 - ListItems pagination performance bottleneck
 **Learning:** Returning large unbounded collections from `GORM.Find()` calls without any `Limit` constraint can cause massive performance and memory issues, especially when paired with `.Preload()`. Using limits and offsets allows for controlled data fetching.
 **Action:** Always verify that endpoint logic correctly limits query results when working with list routes. For backward compatibility, make sure to use reasonable default boundaries (e.g. `1000`) and metadata headers (e.g., `X-Total-Count`).
+## 2026-06-21 - Unbounded Queries with Preloads
+**Learning:** Returning an unbounded set of results (e.g., in `/containers`) via `Find()` along with GORM `.Preload()` statements can cause extreme memory bloat and database overhead on larger datasets, as preloads fetch entire relational graphs for every row.
+**Action:** Always implement pagination (`Limit` and `Offset` along with stable `Order("created_at desc")`) on generic list endpoints, especially those involving multiple preloads.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -264,7 +264,7 @@ const docTemplate = `{
         },
         "/containers": {
             "get": {
-                "description": "Get all containers",
+                "description": "Get containers (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -272,6 +272,20 @@ const docTemplate = `{
                     "Containers"
                 ],
                 "summary": "List Containers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -303,8 +317,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -704,7 +717,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1518,8 +1531,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1554,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -411,7 +407,16 @@ paths:
       - Categories
   /containers:
     get:
-      description: Get all containers
+      description: Get containers (paginated)
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -434,11 +439,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +706,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -44,14 +45,48 @@ func (h *Handler) CreateContainer(c *gin.Context) {
 }
 
 // @Summary List Containers
-// @Description Get all containers
+// @Description Get containers (paginated)
 // @Tags Containers
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Container
 // @Router /containers [get]
 func (h *Handler) ListContainers(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var containers []models.Container
-	h.DB.Preload("Location").Preload("Parent").Preload("Project").Find(&containers)
+	var total int64
+
+	if err := h.DB.Model(&models.Container{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	// ⚡ Bolt: Added pagination and stable sorting to prevent unbounded memory growth and excessive DB load with Preloads
+	if err := h.DB.Preload("Location").Preload("Parent").Preload("Project").Order("created_at desc").Limit(limit).Offset(offset).Find(&containers).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
+	c.Header("X-Limit", strconv.Itoa(limit))
+	c.Header("X-Offset", strconv.Itoa(offset))
+
 	c.JSON(http.StatusOK, containers)
 }
 


### PR DESCRIPTION
💡 **What:** Implemented standard API pagination (limit, offset) and stable sorting (`created_at desc`) to the `/containers` list endpoint, returning standard headers `X-Total-Count`, `X-Limit`, and `X-Offset`.

🎯 **Why:** The previous implementation used an unbounded `Find()` query along with three expensive GORM `.Preload()` commands (`Location`, `Parent`, `Project`). Returning an unbounded set of results under these conditions causes significant memory bloat, out-of-memory risks, and database strain on larger datasets, which goes against the application's goal of running efficiently on low-powered hardware.

📊 **Impact:** Reduces database retrieval times and mitigates memory growth spikes by clamping lists to a maximum bounded threshold of `10000` (defaulting to `1000`). Local synthetic benchmarks on a bounded subset showed performance stabilization compared to potentially exponential query times on unbounded preloads.

🔬 **Measurement:** This was verified locally by establishing a baseline `BenchmarkListContainers` on a 1500-item SQLite test database before and after pagination, and ensuring the tests still correctly execute. The changes can be validated by executing a `GET /containers` request and observing the new headers and a maximum return limit of 1000 entries by default.

---
*PR created automatically by Jules for task [5300981251378171069](https://jules.google.com/task/5300981251378171069) started by @YK12321*