### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix mass assignment vulnerability in UpdateItemType

### DIFF
--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -119,6 +119,9 @@ func (h *Handler) UpdateItemType(c *gin.Context) {
 	}
 	itemType.ID = id // Ensure ID cannot be changed
 
+	// Prevent mass assignment of associations
+	itemType.Category = nil
+
 	if err := h.DB.Save(&itemType).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item type"})
 		return


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Mass assignment vulnerability due to directly saving struct bounded from user input which has a `Category` association (GORM saves associations by default).
🎯 Impact: Attackers could potentially overwrite or create new records in the `Category` table through a carefully crafted JSON payload in an `ItemType` update request.
🔧 Fix: Explicitly nil out the `Category` association on the `itemType` instance before triggering the update in the database.
✅ Verification: The codebase compiles correctly and tests pass.

---
*PR created automatically by Jules for task [15824928262638261489](https://jules.google.com/task/15824928262638261489) started by @YK12321*