### PR TITLE
⚡ Bolt: Add pagination to list endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -63,7 +63,7 @@ const docTemplate = `{
         },
         "/categories": {
             "get": {
-                "description": "Get all categories",
+                "description": "Get categories (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -71,6 +71,20 @@ const docTemplate = `{
                     "Categories"
                 ],
                 "summary": "List Categories",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -264,7 +278,7 @@ const docTemplate = `{
         },
         "/containers": {
             "get": {
-                "description": "Get all containers",
+                "description": "Get containers (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -272,6 +286,20 @@ const docTemplate = `{
                     "Containers"
                 ],
                 "summary": "List Containers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -303,8 +331,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -704,7 +731,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1067,7 +1094,7 @@ const docTemplate = `{
         },
         "/locations": {
             "get": {
-                "description": "Get all locations",
+                "description": "Get locations (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1075,6 +1102,20 @@ const docTemplate = `{
                     "Locations"
                 ],
                 "summary": "List Locations",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1268,7 +1309,7 @@ const docTemplate = `{
         },
         "/projects": {
             "get": {
-                "description": "Get all projects",
+                "description": "Get projects (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1276,6 +1317,20 @@ const docTemplate = `{
                     "Projects"
                 ],
                 "summary": "List Projects",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -1518,8 +1573,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1596,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -278,7 +274,16 @@ paths:
       - Activity Logs
   /categories:
     get:
-      description: Get all categories
+      description: Get categories (paginated)
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -411,7 +416,16 @@ paths:
       - Categories
   /containers:
     get:
-      description: Get all containers
+      description: Get containers (paginated)
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -434,11 +448,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +715,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query
@@ -947,7 +957,16 @@ paths:
       - Items
   /locations:
     get:
-      description: Get all locations
+      description: Get locations (paginated)
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -1080,7 +1099,16 @@ paths:
       - Locations
   /projects:
     get:
-      description: Get all projects
+      description: Get projects (paginated)
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:

--- a/pkg/api/handlers/categories.go
+++ b/pkg/api/handlers/categories.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -36,14 +38,49 @@ func (h *Handler) CreateCategory(c *gin.Context) {
 }
 
 // @Summary List Categories
-// @Description Get all categories
+// @Description Get categories (paginated)
 // @Tags Categories
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Category
 // @Router /categories [get]
 func (h *Handler) ListCategories(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var categories []models.Category
-	h.DB.Find(&categories)
+	var total int64
+
+	// Get total count
+	if err := h.DB.Model(&models.Category{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list categories"})
+		return
+	}
+
+	// Get paginated results with stable sorting
+	if err := h.DB.Order("created_at desc").Limit(limit).Offset(offset).Find(&categories).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list categories"})
+		return
+	}
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, categories)
 }
 

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -44,14 +46,49 @@ func (h *Handler) CreateContainer(c *gin.Context) {
 }
 
 // @Summary List Containers
-// @Description Get all containers
+// @Description Get containers (paginated)
 // @Tags Containers
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Container
 // @Router /containers [get]
 func (h *Handler) ListContainers(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var containers []models.Container
-	h.DB.Preload("Location").Preload("Parent").Preload("Project").Find(&containers)
+	var total int64
+
+	// Get total count
+	if err := h.DB.Model(&models.Container{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	// Get paginated results with stable sorting
+	if err := h.DB.Preload("Location").Preload("Parent").Preload("Project").Order("created_at desc").Limit(limit).Offset(offset).Find(&containers).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list containers"})
+		return
+	}
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, containers)
 }
 

--- a/pkg/api/handlers/locations.go
+++ b/pkg/api/handlers/locations.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/models"
 
@@ -35,14 +37,49 @@ func (h *Handler) CreateLocation(c *gin.Context) {
 }
 
 // @Summary List Locations
-// @Description Get all locations
+// @Description Get locations (paginated)
 // @Tags Locations
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Location
 // @Router /locations [get]
 func (h *Handler) ListLocations(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var locations []models.Location
-	h.DB.Find(&locations)
+	var total int64
+
+	// Get total count
+	if err := h.DB.Model(&models.Location{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list locations"})
+		return
+	}
+
+	// Get paginated results with stable sorting
+	if err := h.DB.Order("created_at desc").Limit(limit).Offset(offset).Find(&locations).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list locations"})
+		return
+	}
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, locations)
 }
 

--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/models"
 
@@ -35,14 +37,49 @@ func (h *Handler) CreateProject(c *gin.Context) {
 }
 
 // @Summary List Projects
-// @Description Get all projects
+// @Description Get projects (paginated)
 // @Tags Projects
 // @Produce json
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Success 200 {array} models.Project
 // @Router /projects [get]
 func (h *Handler) ListProjects(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
 	var projects []models.Project
-	h.DB.Find(&projects)
+	var total int64
+
+	// Get total count
+	if err := h.DB.Model(&models.Project{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list projects"})
+		return
+	}
+
+	// Get paginated results with stable sorting
+	if err := h.DB.Order("created_at desc").Limit(limit).Offset(offset).Find(&projects).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list projects"})
+		return
+	}
+
+	c.Header("X-Total-Count", fmt.Sprintf("%d", total))
+	c.Header("X-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-Offset", fmt.Sprintf("%d", offset))
+
 	c.JSON(http.StatusOK, projects)
 }
 


### PR DESCRIPTION
💡 **What**: Added pagination (`limit` and `offset` query parameters) and stable sorting (`Order("created_at desc")`) to the `/categories`, `/containers`, `/locations`, and `/projects` endpoints.
🎯 **Why**: Returning unbounded lists from a database using `GORM.Find()` without a limit can cause massive performance issues, Out of Memory (OOM) errors, and high database load as tables grow.
📊 **Impact**: This limits the maximum records returned (defaulting to 1000, capped at 10000) and improves responsiveness and stability for these endpoints on large datasets. Also reduces memory footprint for the Go server process significantly under load.
🔬 **Measurement**: Verified by running a benchmark `BenchmarkListContainers` against a seeded memory database, which showed the constrained fetch returns efficiently rather than building massive arrays.

---
*PR created automatically by Jules for task [17222973943457088463](https://jules.google.com/task/17222973943457088463) started by @YK12321*