### PR TITLE
⚡ Bolt: Add pagination to ListContainers to prevent OOM

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-02 - ListItems pagination performance bottleneck
 **Learning:** Returning large unbounded collections from `GORM.Find()` calls without any `Limit` constraint can cause massive performance and memory issues, especially when paired with `.Preload()`. Using limits and offsets allows for controlled data fetching.
 **Action:** Always verify that endpoint logic correctly limits query results when working with list routes. For backward compatibility, make sure to use reasonable default boundaries (e.g. `1000`) and metadata headers (e.g., `X-Total-Count`).
+## 2026-07-05 - Avoid unbounded GORM queries with Preload
+**Learning:** Unbounded `.Find()` queries on endpoints with large datasets (like `ListContainers` or `ListItems`) paired with `.Preload()` associations can consume excessive memory and crash the application, or severely degrade performance.
+**Action:** Always implement pagination with `Limit` and `Offset` along with stable sorting (`.Order("created_at desc")`) on list endpoints that fetch database models with relational associations.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -272,6 +272,20 @@ const docTemplate = `{
                     "Containers"
                 ],
                 "summary": "List Containers",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Limit (default 1000, max 10000)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -303,8 +317,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -704,7 +717,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1518,8 +1531,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1554,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -412,6 +408,15 @@ paths:
   /containers:
     get:
       description: Get all containers
+      parameters:
+      - description: Limit (default 1000, max 10000)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -434,11 +439,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +706,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query

--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"invelog/pkg/dto"
 	"invelog/pkg/models"
@@ -48,10 +49,37 @@ func (h *Handler) CreateContainer(c *gin.Context) {
 // @Tags Containers
 // @Produce json
 // @Success 200 {array} models.Container
+// @Param limit query int false "Limit (default 1000, max 10000)"
+// @Param offset query int false "Offset (default 0)"
 // @Router /containers [get]
 func (h *Handler) ListContainers(c *gin.Context) {
+	limitStr := c.DefaultQuery("limit", "1000")
+	offsetStr := c.DefaultQuery("offset", "0")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		limit = 1000
+	}
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	offset, err := strconv.Atoi(offsetStr)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	var total int64
+	h.DB.Model(&models.Container{}).Count(&total)
+
+	c.Header("X-Total-Count", strconv.FormatInt(total, 10))
+	c.Header("X-Limit", strconv.Itoa(limit))
+	c.Header("X-Offset", strconv.Itoa(offset))
+
 	var containers []models.Container
-	h.DB.Preload("Location").Preload("Parent").Preload("Project").Find(&containers)
+	// Performance optimization: Avoid unbounded GORM queries that consume excessive memory due to `.Preload()`.
+	// Implemented pagination with limit and offset.
+	h.DB.Preload("Location").Preload("Parent").Preload("Project").Order("created_at desc").Limit(limit).Offset(offset).Find(&containers)
 	c.JSON(http.StatusOK, containers)
 }
 


### PR DESCRIPTION
💡 What: Implemented `Limit` and `Offset` pagination with backward-compatible HTTP headers (`X-Total-Count`, `X-Limit`, `X-Offset`) for the `/containers` GET endpoint.
🎯 Why: Unbounded `.Find()` queries on tables with relational associations (`.Preload`) load the entire dataset into memory. In extreme cases, this causes high garbage collection pressure, severe performance degradation, or Out-Of-Memory (OOM) crashes.
📊 Impact: Expected to significantly reduce peak memory usage and response latency when the container table grows large, shifting the operation from `O(N)` to `O(Limit)` in memory consumption per request.
🔬 Measurement: Verified with a temporary benchmark (`BenchmarkListContainers`) simulating 2000 containers. Memory allocations and time per operation dropped drastically compared to unbounded loads. Run the endpoint locally and observe response times and memory profiles under load.

---
*PR created automatically by Jules for task [16805733568968391375](https://jules.google.com/task/16805733568968391375) started by @YK12321*