### PR TITLE
🛡️ Sentinel: [HIGH] Fix Mass Assignment via GORM Associations in ItemType

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+
+## 2024-07-06 - [Mass Assignment via GORM Associations in ItemType]
+**Vulnerability:** The `CreateItemType` and `UpdateItemType` REST endpoints directly bind incoming JSON to the `models.ItemType` domain model. This allows unauthorized updates to the nested `Category` relation when GORM creates/updates records, posing a mass assignment vulnerability.
+**Learning:** Always bind incoming payloads to distinct Data Transfer Objects (DTOs) for creation, and explicitly clear nested relation pointers (e.g. `itemType.Category = nil`) when updating via partial binding to prevent accidental association updates.
+**Prevention:** Use DTOs in `pkg/dto/` for creation, and set association pointers to `nil` before saving during updates.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -303,8 +303,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.Container"
-                            "$ref": "#/definitions/invelog_pkg_dto.CreateContainerRequest"
+                            "$ref": "#/definitions/dto.CreateContainerRequest"
                         }
                     }
                 ],
@@ -542,7 +541,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ItemType"
+                            "$ref": "#/definitions/dto.CreateItemTypeRequest"
                         }
                     }
                 ],
@@ -704,7 +703,7 @@ const docTemplate = `{
         },
         "/items": {
             "get": {
-                "description": "Get all items",
+                "description": "Get items (paginated)",
                 "produces": [
                     "application/json"
                 ],
@@ -1518,8 +1517,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "dto.CreateItemRequest": {
-        "invelog_pkg_dto.CreateContainerRequest": {
+        "dto.CreateContainerRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -1542,7 +1540,7 @@ const docTemplate = `{
                 }
             }
         },
-        "invelog_pkg_dto.CreateItemRequest": {
+        "dto.CreateItemRequest": {
             "type": "object",
             "properties": {
                 "category_id": {
@@ -1570,6 +1568,32 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "serial_number": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.CreateItemTypeRequest": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "category_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "manufacturer": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "part_number": {
+                    "type": "string"
+                },
+                "specifications": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,9 +1,6 @@
 basePath: /api/v1
 definitions:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-  dto.CreateItemRequest:
-=======
-  invelog_pkg_dto.CreateContainerRequest:
+  dto.CreateContainerRequest:
     properties:
       description:
         type: string
@@ -18,8 +15,7 @@ definitions:
     required:
     - name
     type: object
-  invelog_pkg_dto.CreateItemRequest:
->>>>>>> main
+  dto.CreateItemRequest:
     properties:
       category_id:
         type: string
@@ -39,6 +35,23 @@ definitions:
         type: integer
       serial_number:
         type: string
+    type: object
+  dto.CreateItemTypeRequest:
+    properties:
+      category_id:
+        type: string
+      description:
+        type: string
+      manufacturer:
+        type: string
+      name:
+        type: string
+      part_number:
+        type: string
+      specifications:
+        type: string
+    required:
+    - name
     type: object
   dto.UpdateCategoryInput:
     properties:
@@ -434,11 +447,7 @@ paths:
         name: container
         required: true
         schema:
-<<<<<<< bolt-performance-pagination-items-17337018210979591320
-          $ref: '#/definitions/models.Container'
-=======
-          $ref: '#/definitions/invelog_pkg_dto.CreateContainerRequest'
->>>>>>> main
+          $ref: '#/definitions/dto.CreateContainerRequest'
       produces:
       - application/json
       responses:
@@ -595,7 +604,7 @@ paths:
         name: itemType
         required: true
         schema:
-          $ref: '#/definitions/models.ItemType'
+          $ref: '#/definitions/dto.CreateItemTypeRequest'
       produces:
       - application/json
       responses:
@@ -705,7 +714,7 @@ paths:
       - ItemTypes
   /items:
     get:
-      description: Get all items
+      description: Get items (paginated)
       parameters:
       - description: Limit (default 1000, max 10000)
         in: query

--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"invelog/pkg/dto"
 	"invelog/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -15,15 +16,24 @@ import (
 // @Tags ItemTypes
 // @Accept json
 // @Produce json
-// @Param itemType body models.ItemType true "ItemType Data"
+// @Param itemType body dto.CreateItemTypeRequest true "ItemType Data"
 // @Success 201 {object} models.ItemType
 // @Failure 400 {object} map[string]string
 // @Router /item-types [post]
 func (h *Handler) CreateItemType(c *gin.Context) {
-	var itemType models.ItemType
-	if err := c.ShouldBindJSON(&itemType); err != nil {
+	var req dto.CreateItemTypeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
+	}
+
+	itemType := models.ItemType{
+		Name:           req.Name,
+		Description:    req.Description,
+		Specifications: req.Specifications,
+		Manufacturer:   req.Manufacturer,
+		PartNumber:     req.PartNumber,
+		CategoryID:     req.CategoryID,
 	}
 
 	if err := h.DB.Create(&itemType).Error; err != nil {
@@ -118,6 +128,9 @@ func (h *Handler) UpdateItemType(c *gin.Context) {
 		return
 	}
 	itemType.ID = id // Ensure ID cannot be changed
+
+	// Prevent mass assignment of Category
+	itemType.Category = nil
 
 	if err := h.DB.Save(&itemType).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update item type"})

--- a/pkg/dto/item_type.go
+++ b/pkg/dto/item_type.go
@@ -1,0 +1,12 @@
+package dto
+
+import "github.com/google/uuid"
+
+type CreateItemTypeRequest struct {
+    Name           string     `json:"name" binding:"required"`
+    Description    string     `json:"description"`
+    Specifications string     `json:"specifications"`
+    Manufacturer   string     `json:"manufacturer"`
+    PartNumber     string     `json:"part_number"`
+    CategoryID     *uuid.UUID `json:"category_id"`
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `CreateItemType` and `UpdateItemType` REST endpoints directly bind incoming JSON to the `models.ItemType` domain model. This allows unauthorized updates to the nested `Category` relation when GORM creates/updates records, posing a mass assignment vulnerability.
🎯 **Impact:** An attacker could modify the attributes of an existing `Category` (or create unauthorized links) by passing nested JSON (e.g., `{"category": {"name": "Hacked"}}`) during item type creation or updates.
🔧 **Fix:** Introduced a strict Data Transfer Object (`dto.CreateItemTypeRequest`) for creation that excludes the full `Category` object. For updates, strategically set the relational pointer `itemType.Category = nil` prior to saving, successfully blocking GORM from inadvertently overwriting associated database records.
✅ **Verification:** Run `go test ./...` to ensure all tests pass. Swagger definitions were also updated and checked using `git diff`.

---
*PR created automatically by Jules for task [2814266724897613632](https://jules.google.com/task/2814266724897613632) started by @YK12321*