### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix mass assignment vulnerability in UpdateContainer

### DIFF
--- a/pkg/api/handlers/containers.go
+++ b/pkg/api/handlers/containers.go
@@ -113,7 +113,7 @@ func (h *Handler) GetContainer(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param id path string true "Container ID"
-// @Param container body models.Container true "Container Data"
+// @Param container body dto.UpdateContainerInput true "Container Data"
 // @Success 200 {object} models.Container
 // @Failure 400 {object} map[string]string
 // @Failure 404 {object} map[string]string
@@ -131,13 +131,28 @@ func (h *Handler) UpdateContainer(c *gin.Context) {
 		return
 	}
 
-	if err := c.ShouldBindJSON(&container); err != nil {
+	var input dto.UpdateContainerInput
+	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	container.ID = id // Ensure ID cannot be changed
 
-	// Prevent mass assignment of associations
+	if input.Name != nil {
+		container.Name = *input.Name
+	}
+	if input.Description != nil {
+		container.Description = *input.Description
+	}
+	if input.LocationID != nil {
+		container.LocationID = input.LocationID
+	}
+	if input.ParentID != nil {
+		container.ParentID = input.ParentID
+	}
+	if input.ProjectID != nil {
+		container.ProjectID = input.ProjectID
+	}
+
 	container.Location = nil
 	container.Parent = nil
 	container.Project = nil

--- a/pkg/dto/container.go
+++ b/pkg/dto/container.go
@@ -9,3 +9,11 @@ type CreateContainerRequest struct {
 	ParentID    *uuid.UUID `json:"parent_id"`
 	ProjectID   *uuid.UUID `json:"project_id"`
 }
+
+type UpdateContainerInput struct {
+	Name        *string    `json:"name"`
+	Description *string    `json:"description"`
+	LocationID  *uuid.UUID `json:"location_id"`
+	ParentID    *uuid.UUID `json:"parent_id"`
+	ProjectID   *uuid.UUID `json:"project_id"`
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Mass Assignment via GORM associations. The `/api/v1/containers/{id}` endpoint used `ShouldBindJSON` directly on `models.Container`, enabling attackers to supply nested object data for relational fields (`Location`, `Parent`, `Project`) that would be saved automatically if specific driver settings like `FullSaveAssociations` were ever toggled. Even without this, binding straight to the domain model makes scalar ID assignment vulnerable.
🎯 Impact: Attackers could potentially re-parent containers they shouldn't, change a container's project, or write arbitrary nested objects (like creating new locations unknowingly) leading to broken data integrity.
🔧 Fix: Created `UpdateContainerInput` in `pkg/dto/container.go` to safely accept updates via pointers. The `UpdateContainer` handler in `pkg/api/handlers/containers.go` now binds to the DTO and manually maps the scalar fields (`Name`, `LocationID`, etc.) before updating.
✅ Verification: Ran `go test ./...` which passes. Confirmed the Swagger documentation is updated to reference the new DTO.

---
*PR created automatically by Jules for task [2527872830923138538](https://jules.google.com/task/2527872830923138538) started by @YK12321*