### PR TITLE
⚡ Bolt: Optimize GetAuditSummary with database-level aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-02 - ListItems pagination performance bottleneck
 **Learning:** Returning large unbounded collections from `GORM.Find()` calls without any `Limit` constraint can cause massive performance and memory issues, especially when paired with `.Preload()`. Using limits and offsets allows for controlled data fetching.
 **Action:** Always verify that endpoint logic correctly limits query results when working with list routes. For backward compatibility, make sure to use reasonable default boundaries (e.g. `1000`) and metadata headers (e.g., `X-Total-Count`).
+## 2024-08-01 - AuditSummary unbounded collection performance bottleneck
+**Learning:** Fetching unbounded slices of data into memory for metric computation (e.g. `Find(&logs)`) creates an O(N) memory and processing bottleneck that scales poorly with data volume.
+**Action:** Always push aggregations (like SUM, COUNT, MAX) down to the database level using `Select` combined with database aggregation functions (like `SUM` and `CASE WHEN`) and `Scan`.

--- a/pkg/api/handlers/items.go
+++ b/pkg/api/handlers/items.go
@@ -515,30 +515,27 @@ func (h *Handler) AuditItem(c *gin.Context) {
 // @Router /audit/summary [get]
 func (h *Handler) GetAuditSummary(c *gin.Context) {
 	var totalAudits int64
-	var posDrift int64
-	var negDrift int64
 	var totalItems int64
 
 	h.DB.Model(&models.ActivityLog{}).Where("action = ?", "QUANTITY_ADJUSTED").Count(&totalAudits)
 	h.DB.Model(&models.Item{}).Count(&totalItems)
 
-	var logs []models.ActivityLog
-	h.DB.Where("action = ?", "QUANTITY_ADJUSTED").Find(&logs)
-
-	for _, l := range logs {
-		if l.QuantityChange > 0 {
-			posDrift += int64(l.QuantityChange)
-		} else if l.QuantityChange < 0 {
-			negDrift += int64(l.QuantityChange)
-		}
+	// Bolt Optimization: Push aggregation to the database to avoid fetching potentially huge unbound slices into memory.
+	var drift struct {
+		PosDrift int64
+		NegDrift int64
 	}
+	h.DB.Model(&models.ActivityLog{}).
+		Select("COALESCE(SUM(CASE WHEN quantity_change > 0 THEN quantity_change ELSE 0 END), 0) as pos_drift, COALESCE(SUM(CASE WHEN quantity_change < 0 THEN quantity_change ELSE 0 END), 0) as neg_drift").
+		Where("action = ?", "QUANTITY_ADJUSTED").
+		Scan(&drift)
 
 	c.JSON(http.StatusOK, dto.AuditSummaryResponse{
 		TotalAudits:   totalAudits,
 		TotalItems:    totalItems,
-		PositiveDrift: posDrift,
-		NegativeDrift: negDrift,
-		NetDrift:      posDrift + negDrift,
+		PositiveDrift: drift.PosDrift,
+		NegativeDrift: drift.NegDrift,
+		NetDrift:      drift.PosDrift + drift.NegDrift,
 	})
 }
 


### PR DESCRIPTION
💡 What: Refactored the `GetAuditSummary` endpoint in `pkg/api/handlers/items.go` to push the positive and negative drift metric calculations directly to the database level using SQL `SUM` and `CASE WHEN`.

🎯 Why: Previously, the endpoint fetched an unbounded collection of all `ActivityLog` records matching the 'QUANTITY_ADJUSTED' action into application memory using `h.DB.Find(&logs)` and iterated over them in a loop. This created a severe O(N) memory and processing bottleneck that scaled poorly as the audit log grew, leading to potential Out-Of-Memory (OOM) errors and slow response times.

📊 Impact: Significantly reduces application memory footprint, network data transfer overhead from the database, and CPU processing time for the endpoint. It changes an O(N) memory and data-transfer operation into an O(1) memory operation on the application side, relying on the database's highly optimized aggregation engine instead.

🔬 Measurement: I used Go's benchmarking suite (temporarily via `benchmark_test.go`) to measure the performance before the change. The execution time and memory allocations drop significantly when processing hundreds/thousands of records. The existing test suite was run (`go test ./...`) and continues to pass, ensuring the API output strictly matches the previous behavior.

---
*PR created automatically by Jules for task [6202165479120638555](https://jules.google.com/task/6202165479120638555) started by @YK12321*