### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+## 2024-08-04 - Fix hardcoded JWT secret
+
+**Vulnerability:** A hardcoded, highly predictable JWT secret fallback (`"invelog-default-secret-key-change-in-prod"`) was present in `pkg/api/middleware/auth.go`.
+**Learning:** Hardcoded fallbacks are extremely dangerous and can allow attackers to easily forge admin tokens in environments that omit setting the required configuration variables.
+**Prevention:** If an environment variable is required for cryptographic security but absent, always use a cryptographically strong, randomly generated ephemeral secret. This fail-safe approach means tokens invalidate upon server restart, but the system remains secure against token forging attacks without causing an immediate application crash.

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"crypto/rand"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -14,10 +16,20 @@ import (
 	"github.com/google/uuid"
 )
 
+var ephemeralSecret []byte
+
+func init() {
+	ephemeralSecret = make([]byte, 32)
+	if _, err := rand.Read(ephemeralSecret); err != nil {
+		log.Fatalf("failed to generate fallback jwt secret: %v", err)
+	}
+}
+
 func getJWTSecret() []byte {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		secret = "invelog-default-secret-key-change-in-prod"
+		log.Println("WARNING: JWT_SECRET environment variable is not set. Using ephemeral random secret (tokens will invalidate on restart).")
+		return ephemeralSecret
 	}
 	return []byte(secret)
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used a predictable, hardcoded fallback string for `JWT_SECRET` when the environment variable was missing.
🎯 Impact: Attackers could forge admin tokens in environments that failed to explicitly configure the JWT secret, leading to complete system compromise.
🔧 Fix: Replaced the static string fallback with a 32-byte cryptographically secure random secret generated at application startup (`crypto/rand`). This ensures tokens validate securely but fail securely (invalidate upon server restart) if the environment variable is not configured.
✅ Verification: Tested locally via test suite, verified logging output on startup.

---
*PR created automatically by Jules for task [9132873991438392172](https://jules.google.com/task/9132873991438392172) started by @YK12321*