### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret fallback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+
+## 2026-08-12 - [Hardcoded JWT Secret Fallback]
+**Vulnerability:** The application used a hardcoded default string ("invelog-default-secret-key-change-in-prod") for signing JWTs when the JWT_SECRET environment variable was omitted.
+**Learning:** Providing a static, known string as a fallback for missing cryptographic secrets completely undermines token-based authentication, as attackers can forge tokens with the known secret.
+**Prevention:** If an application must continue running without configured secrets to prevent startup crashes, it must generate a cryptographically strong, ephemeral secret at runtime (e.g., using `crypto/rand` in `init()`), ensuring forged tokens from external sources cannot be validated.

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,10 +15,19 @@ import (
 	"github.com/google/uuid"
 )
 
+var ephemeralSecret []byte
+
+func init() {
+	ephemeralSecret = make([]byte, 32)
+	// Generate a cryptographically strong random secret at startup
+	// to prevent forged token attacks when JWT_SECRET is missing.
+	_, _ = rand.Read(ephemeralSecret)
+}
+
 func getJWTSecret() []byte {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		secret = "invelog-default-secret-key-change-in-prod"
+		return ephemeralSecret
 	}
 	return []byte(secret)
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used a hardcoded fallback string for signing JWT tokens if the JWT_SECRET environment variable was missing.
🎯 Impact: An attacker who knows this public codebase could forge valid admin JWT tokens for any deployment that neglected to set a JWT_SECRET, granting full unauthorized access.
🔧 Fix: Replaced the static fallback string with an ephemeral, cryptographically strong random secret generated at application startup using `crypto/rand`.
✅ Verification: `go test ./...` passes successfully.

---
*PR created automatically by Jules for task [11401943070253971739](https://jules.google.com/task/11401943070253971739) started by @YK12321*