### PR TITLE
⚡ Bolt: Resolve N+1 query in GetLowStockItemTypes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-02 - ListItems pagination performance bottleneck
 **Learning:** Returning large unbounded collections from `GORM.Find()` calls without any `Limit` constraint can cause massive performance and memory issues, especially when paired with `.Preload()`. Using limits and offsets allows for controlled data fetching.
 **Action:** Always verify that endpoint logic correctly limits query results when working with list routes. For backward compatibility, make sure to use reasonable default boundaries (e.g. `1000`) and metadata headers (e.g., `X-Total-Count`).
+## 2024-06-02 - GetLowStockItemTypes N+1 Optimization
+**Learning:** The previous implementation of `GetLowStockItemTypes` fetched all item types and then executed a separate `SUM(quantity)` query inside a loop for each item type to calculate total quantities. This O(N) query pattern caused significant database overhead and performance degradation as the number of items grew.
+**Action:** Replaced the loop with a single optimized SQL query using GORM's `.Joins()`, `.Group()`, and `.Having()` to push the computation and filtering down to the database level, efficiently resolving the N+1 problem.

--- a/pkg/api/handlers/item_types.go
+++ b/pkg/api/handlers/item_types.go
@@ -268,19 +268,18 @@ func (h *Handler) DeleteItemType(c *gin.Context) {
 // @Success 200 {array} models.ItemType
 // @Router /item-types/low-stock [get]
 func (h *Handler) GetLowStockItemTypes(c *gin.Context) {
-	var allTypes []models.ItemType
-	if err := h.DB.Preload("Category").Where("min_quantity > 0").Find(&allTypes).Error; err != nil {
+	var lowStockTypes []models.ItemType
+
+	// ⚡ Bolt: Replaced O(N) loop queries with a single database aggregation query
+	// This pushes the sum computation down to the database and eliminates the N+1 problem.
+	if err := h.DB.Preload("Category").
+		Joins("LEFT JOIN items ON items.item_type_id = item_types.id AND items.deleted_at IS NULL").
+		Where("item_types.min_quantity > 0").
+		Group("item_types.id").
+		Having("COALESCE(SUM(items.quantity), 0) <= item_types.min_quantity").
+		Find(&lowStockTypes).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch item types"})
 		return
-	}
-
-	var lowStockTypes []models.ItemType
-	for _, it := range allTypes {
-		var totalQty int64
-		h.DB.Model(&models.Item{}).Where("item_type_id = ?", it.ID).Select("COALESCE(SUM(quantity), 0)").Scan(&totalQty)
-		if int(totalQty) <= it.MinQuantity {
-			lowStockTypes = append(lowStockTypes, it)
-		}
 	}
 
 	c.JSON(http.StatusOK, lowStockTypes)


### PR DESCRIPTION
💡 What: Replaced an N+1 query loop in `GetLowStockItemTypes` with a single SQL aggregation query using `Joins`, `Group`, and `Having`.
🎯 Why: The original implementation fetched all item types and then executed a separate `SUM()` query for each type inside a loop, causing significant performance and database load degradation as the number of item types grew.
📊 Impact: Expected to drastically reduce database queries from O(N) to O(1) and improve response time.
🔬 Measurement: Verify by running `go test ./pkg/api/handlers -bench=BenchmarkGetLowStockItemTypes` before and after the change.

---
*PR created automatically by Jules for task [10623987406227224846](https://jules.google.com/task/10623987406227224846) started by @YK12321*