### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded JWT secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Several REST endpoints (e.g., `CreateContainer`, `UpdateContainer`) were directly binding incoming JSON payloads to GORM domain models (`models.Container`). When database configurations enable `FullSaveAssociations` (common when migrating from SQLite to Postgres or modifying defaults), this allows attackers to pass nested JSON objects (like `{"location": {"name": "Hacked"}}`) and perform unauthorized mass assignment/modifications on related database records.
 **Learning:** Directly binding HTTP requests to domain models that have relation mappings (like `Location`, `Project`, `Parent`) creates a dangerous mass assignment vector that might lay dormant until ORM settings or DB drivers are changed.
 **Prevention:** Always use dedicated Data Transfer Objects (DTOs) for request parsing (e.g., in `pkg/dto/`) that only expose primitive scalar fields (e.g., `LocationID` instead of a full `Location` object) and strictly defined allowed updateable fields, then map these explicitly to domain models before saving.
+
+## 2026-08-13 - Remove Hardcoded JWT Secret Fallback
+**Vulnerability:** A static, hardcoded JWT secret ('invelog-default-secret-key-change-in-prod') was used as a fallback when the JWT_SECRET environment variable was missing.
+**Learning:** Using a static fallback for cryptographic secrets allows attackers to forge valid tokens if the environment variable is accidentally omitted in production.
+**Prevention:** Always fallback to a cryptographically strong, randomly generated ephemeral secret (e.g., using `crypto/rand` in `init()`) so the application remains secure even if misconfigured, without crashing.

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"crypto/rand"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,10 +15,20 @@ import (
 	"github.com/google/uuid"
 )
 
+var ephemeralSecret []byte
+
+func init() {
+	ephemeralSecret = make([]byte, 32)
+	if _, err := rand.Read(ephemeralSecret); err != nil {
+		panic("failed to generate ephemeral JWT secret: " + err.Error())
+	}
+}
+
 func getJWTSecret() []byte {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		secret = "invelog-default-secret-key-change-in-prod"
+		// Security: Fallback to a cryptographically strong ephemeral secret
+		return ephemeralSecret
 	}
 	return []byte(secret)
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used a static, hardcoded JWT secret ('invelog-default-secret-key-change-in-prod') as a fallback when the `JWT_SECRET` environment variable was not set.
🎯 Impact: If the environment variable was accidentally omitted in a production deployment, an attacker could use the known hardcoded secret to forge valid JWT tokens and bypass authentication entirely, gaining unauthorized access to any account.
🔧 Fix: Replaced the hardcoded fallback with a cryptographically strong, randomly generated ephemeral secret created at application startup (`init()`). This ensures the application remains secure without crashing if the configuration is missing.
✅ Verification: Tested the fix by running the test suite (`go test ./...`), confirming the changes are syntactically correct and don't introduce regressions.

---
*PR created automatically by Jules for task [18157542750655815999](https://jules.google.com/task/18157542750655815999) started by @YK12321*